### PR TITLE
doc: Improve ccv0.sh and CCv0 how-to document

### DIFF
--- a/docs/how-to/ccv0.sh
+++ b/docs/how-to/ccv0.sh
@@ -265,7 +265,7 @@ create_a_local_rootfs() {
     pushd ${katacontainers_repo_dir}/tools/osbuilder/rootfs-builder
     export distro="ubuntu"
     [[ -z "${USE_PODMAN:-}" ]] && use_docker="${use_docker:-1}"
-    sudo -E OS_VERSION="${OS_VERSION:-}" GOPATH=$GOPATH DEBUG="${DEBUG}" USE_DOCKER="${use_docker:-}" SKOPEO=${SKOPEO:-} UMOCI=yes SECCOMP=yes ./rootfs.sh -r ${ROOTFS_DIR} ${distro}
+    sudo -E OS_VERSION="${OS_VERSION:-}" GOPATH=$GOPATH EXTRA_PKGS="vim iputils-ping net-tools" DEBUG="${DEBUG}" USE_DOCKER="${use_docker:-}" SKOPEO=${SKOPEO:-} UMOCI=yes SECCOMP=yes ./rootfs.sh -r ${ROOTFS_DIR} ${distro}
 
      # Install_rust.sh during rootfs.sh switches us to the main branch of the tests repo, so switch back now
     pushd "${tests_repo_dir}"


### PR DESCRIPTION
General doc enchancements including:
- Change `cd`s for `pushd` and `popd`s
- Remove hard coded architectures
- Tighten up the security where we `chmod 777`
- Add support for not running as source
- Updates so it doesn't do `ctr pull` if the image is on the
 local system already
- Doc and Test running as non-root user (covered by #2879)
- Update doc to match image_rpc changes

Fixes: #3549
Fixes: #2879
Signed-off-by: stevenhorsman <steven@uk.ibm.com>