### PR TITLE
runtime: share sandboxUID in hyperv-config

### DIFF
--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -464,6 +464,9 @@ type HypervisorConfig struct {
 	// The name of the namespace of the sandbox (pod)
 	SandboxNamespace string
 
+	// The uid of the sandbox (pod)
+	SandboxUID string
+
 	// The user maps to the uid.
 	User string
 

--- a/src/runtime/virtcontainers/remote.go
+++ b/src/runtime/virtcontainers/remote.go
@@ -74,6 +74,10 @@ func (rh *remoteHypervisor) CreateVM(ctx context.Context, id string, network Net
 	annotations := map[string]string{}
 	annotations[cri.SandboxName] = hypervisorConfig.SandboxName
 	annotations[cri.SandboxNamespace] = hypervisorConfig.SandboxNamespace
+	// This value is available in containerd >v1.6.11
+	// once we have updated to later verison we can use cri.SandboxUID
+	criSandboxUID := "io.kubernetes.cri.sandbox-uid"
+	annotations[criSandboxUID] = hypervisorConfig.SandboxUID
 
 	req := &pb.CreateVMRequest{
 		Id:                   id,

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -637,6 +637,15 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 				sandboxConfig.HypervisorConfig.SandboxNamespace = value
 			}
 		}
+
+		// This value is available in containerd >v1.6.11
+		// once we have updated to later verison we can use cri.SandboxUID
+		criSandboxUID := "io.kubernetes.cri.sandbox-uid"
+		for _, a := range []string{criSandboxUID, crio.SandboxID} {
+			if value, ok := sandboxConfig.Containers[0].Annotations[a]; ok {
+				sandboxConfig.HypervisorConfig.SandboxUID = value
+			}
+		}
 	}
 
 	// If we have a confidential guest we need to cold-plug the PCIe VFIO devices


### PR DESCRIPTION
The sandboxUID is required to reference the pod object.